### PR TITLE
fix: updated datatable and pie performance

### DIFF
--- a/src/finance/components/report-datatable.component.vue
+++ b/src/finance/components/report-datatable.component.vue
@@ -1,25 +1,16 @@
 <script>
-import { Report } from "../model/report.entity.js";
-import { ReportService } from "../services/report.service.js";
-
 export default {
   name: "report-datatable",
-  data() {
-    return {
-      reports: [],
-      reportService: null
+  props: {
+    reports: {
+      type: Array,
+      required: true
     }
   },
   methods: {
     getRowType(data) {
       return data.type === 'income' ? 'income-row' : 'expense-row';
     }
-  },
-  created() {
-    this.reportService = new ReportService();
-    this.reportService.getAll().then(response => {
-      this.reports = response.data.map(report => new Report(report));
-    }).catch(e => console.error(e));
   }
 }
 </script>

--- a/src/finance/components/report-pie.component.vue
+++ b/src/finance/components/report-pie.component.vue
@@ -1,13 +1,14 @@
 <script>
-import {Report} from "../model/report.entity.js";
-import {ReportService} from "../services/report.service.js";
-
 export default {
   name: "report-pie",
+  props: {
+    reports: {
+      type: Array,
+      required: true
+    }
+  },
   data() {
     return {
-      reports: [],
-      reportService: null,
       chartData: null,
       chartOptions: {
         responsive: true,
@@ -28,26 +29,24 @@ export default {
         datasets: [
           {
             data: [incomeSum, expenseSum],
-            backgroundColor: [
-              "#aefaa6",
-              "#f3666b",
-            ],
-            hoverBackgroundColor: [
-              "#aefaa6",
-              "#f3666b",
-            ]
+            backgroundColor: ["#aefaa6", "#f3666b"],
+            hoverBackgroundColor: ["#aefaa6", "#f3666b"]
           }
         ]
       };
     }
   },
+  watch: {
+    reports: {
+      handler() {
+        this.chartData = this.setChartData();
+      },
+      deep: true,
+      immediate: true
+    }
+  },
   created() {
-    this.reportService = new ReportService();
-    this.reportService.getAll().then(response => {
-      this.reports = response.data.map(report => new Report(report));
-      this.chartData = this.setChartData();
-    }).catch(e => console.error(e));
-
+    this.chartData = this.setChartData();
   }
 }
 </script>

--- a/src/finance/pages/finance-overview.component.vue
+++ b/src/finance/pages/finance-overview.component.vue
@@ -1,10 +1,24 @@
 <script>
+import { Report } from "../model/report.entity.js";
+import { ReportService } from "../services/report.service.js";
 import ReportPie from "../components/report-pie.component.vue";
 import ReportDatatable from "../components/report-datatable.component.vue";
 import DateFilter from "../components/date-filter.component.vue";
 export default {
   name: "finance-overview",
-  components: {ReportPie, ReportDatatable, DateFilter}
+  components: {ReportPie, ReportDatatable, DateFilter},
+  data() {
+    return {
+      reports: [],
+      reportService: null
+    }
+  },
+  created() {
+    this.reportService = new ReportService();
+    this.reportService.getAll().then(response => {
+      this.reports = response.data.map(report => new Report(report));
+    }).catch(e => console.error(e));
+  }
 }
 </script>
 
@@ -31,8 +45,8 @@ export default {
       </div>
     </div>
     <div>
-      <report-pie/>
-      <report-datatable/>
+      <report-pie :reports="reports"/>
+      <report-datatable :reports="reports"/>
     </div>
 
   </div>


### PR DESCRIPTION
The page calls the service once and parses the report array to its components instead of each component calling the service, resulting in 2 calls and decreasing performance.